### PR TITLE
Fix `rng.sample()` call for Python 3.11

### DIFF
--- a/propulate/propagators.py
+++ b/propulate/propagators.py
@@ -241,7 +241,7 @@ class PointMutation(Stochastic):
             # Determine traits to mutate via random sampling.
             # Return `self.points` length list of unique elements chosen from `ind.keys()`.
             # Used for random sampling without replacement.
-            to_mutate = self.rng.sample(ind.keys(), self.points)
+            to_mutate = self.rng.sample(sorted(ind.keys()), self.points)
             # Point-mutate `self.points` randomly chosen traits of individual `ind`.
             for i in to_mutate:
                 if type(ind[i]) == int:
@@ -325,7 +325,7 @@ class RandomPointMutation(Stochastic):
             # Return `self.points` length list of unique elements chosen from `ind.keys()`.
             # Used for random sampling without replacement.
             points = self.rng.randint(self.min_points, self.max_points)
-            to_mutate = self.rng.sample(ind.keys(), points)
+            to_mutate = self.rng.sample(sorted(ind.keys()), points)
             # Point-mutate `points` randomly chosen traits of individual `ind`.
             for i in to_mutate:
                 if type(ind[i]) == int:


### PR DESCRIPTION
Closes #13

*Note*: This branch is NOT based off `master`, but instead `release` (3e85556) which I assume corresponds to version 0.0.1 on pypi and is used in #13 (there are no github releases or tags in this project).

With commits later than `release` (3e85556) I get 

```
ImportError: cannot import name 'Islands' from 'propulate'
```