### PR TITLE
Iss39 - Remove inter-island communicator.

### DIFF
--- a/propulate/islands.py
+++ b/propulate/islands.py
@@ -37,6 +37,8 @@ class Islands:
                   loss function to be minimized
         propagator : propulate.propagators.Propagator
                      propagator to apply for breeding
+        rng : random.Random()
+              random number generator
         generations : int
                       number of generations
         num_isles : int
@@ -71,7 +73,7 @@ class Islands:
             generations
         )  # number of generations, i.e., evaluations per individual
 
-        # Set up communicators.
+        # Set up communicator.
         size = MPI.COMM_WORLD.size
         rank = MPI.COMM_WORLD.rank
 
@@ -84,13 +86,13 @@ class Islands:
         if isle_sizes is None:
             if num_isles < 1:
                 raise ValueError(
-                    f"Invalid number of evolutionary isles, needs to be >= 1, but was {num_isles}."
+                    f"Invalid number of evolutionary islands, needs to be >= 1, but was {num_isles}."
                 )
             num_isles = int(num_isles)  # number of separate isles
             base_size = int(size // num_isles)  # base size of each isle
             remainder = int(
                 size % num_isles
-            )  # remaining workers to be distributed equally for load balancing
+            )  # Distribute remaining workers equally over first islands for balanced load.
 
             isle_sizes = []
             for i in range(num_isles):
@@ -107,45 +109,34 @@ class Islands:
                 f"There should be MPI.COMM_WORLD.size (i.e., {size}) workers but only {np.sum(isle_sizes)} were specified."
             )
 
-        # intra-isle communicator (for communication within each separate isle)
+        #  Set up intra-island communicator (for communication within each separate island)
         Intra_color = []
         for idx, el in enumerate(isle_sizes):
             Intra_color.append(idx * np.ones(el, dtype=int))
         Intra_color = np.concatenate(Intra_color).ravel()
-        intra_color = Intra_color[rank]
+        isle_idx = Intra_color[rank] # Determine isle index (which is also each rank's intra color).
         intra_key = rank
 
-        # inter-isle communicator (for communication between different isles)
-        # Determine unique elements, where # unique elements equals number of isles.
+        # Determine displacements as positions of unique elements, where # unique elements equals number of islands.
         _, unique_ind = np.unique(Intra_color, return_index=True)
-        num_isles = (
+        num_isles == (
             unique_ind.size
-        )  # Determine number of isles as number of unique elements.
-        Inter_color = np.zeros(size)  # Initialize inter color with only zeros.
+        )  # Determine number of islands as number of unique elements.
+
         if rank == 0:
             print(
                 f"Island sizes {Intra_color} with counts {isle_sizes} and start displacements {unique_ind}."
             )
-        Inter_color[unique_ind] = 1
-        inter_color = Inter_color[rank]
-        inter_key = rank
 
-        # Create new communicators by "splitting" MPI.COMM_WORLD into group of sub-communicators based on
+        # Create new communicators by splitting MPI.COMM_WORLD into group of sub-communicators based on
         # input values `color` and `key`. The original communicator does not go away but a new communicator
         # is created on each process. `color` determines to which new communicator each processes will belong.
-        # All processes which pass in the same value for `color` are assigned to the same communicator. `key`
-        # determines the ordering (rank) within each new communicator. The process which passes in the smallest
+        # All processes passing the same value for `color` are assigned to the same communicator. `key`
+        # determines the ordering (rank) within each new communicator. The process passing the smallest
         # value for `key` will be rank 0 and so on.
-        comm_intra = MPI.COMM_WORLD.Split(color=intra_color, key=intra_key)
-        comm_inter = MPI.COMM_WORLD.Split(color=inter_color, key=inter_key)
+        comm_intra = MPI.COMM_WORLD.Split(color=isle_idx, key=intra_key)
 
-        # Determine isle index and broadcast to all ranks in intra-isle communicator.
-        if comm_intra.rank == 0:
-            isle_idx = comm_inter.rank
-        else:
-            isle_idx = None
-        isle_idx = comm_intra.bcast(isle_idx, root=0)
-
+        # Set up migration topology.
         if migration_topology is None:
             migration_topology = np.ones((num_isles, num_isles), dtype=int)
             np.fill_diagonal(migration_topology, 0)
@@ -193,7 +184,6 @@ class Islands:
                 generations=generations,
                 isle_idx=isle_idx,
                 checkpoint_path=checkpoint_path,
-                comm_inter=comm_inter,
                 migration_topology=migration_topology,
                 migration_prob=migration_prob,
                 emigration_propagator=emigration_propagator,
@@ -211,7 +201,6 @@ class Islands:
                 generations=generations,
                 isle_idx=isle_idx,
                 checkpoint_path=checkpoint_path,
-                comm_inter=comm_inter,
                 migration_topology=migration_topology,
                 migration_prob=migration_prob,
                 emigration_propagator=emigration_propagator,

--- a/propulate/pollinator.py
+++ b/propulate/pollinator.py
@@ -31,7 +31,6 @@ class PolliPropulator:
         generations=0,
         checkpoint_path=Path('./'),
         migration_topology=None,
-        comm_inter=MPI.COMM_WORLD,
         migration_prob=None,
         emigration_propagator=None,
         immigration_propagator=None,
@@ -61,8 +60,6 @@ class PolliPropulator:
         migration_topology : numpy array
                              2D matrix where entry (i,j) specifies how many
                              individuals are sent by isle i to isle j
-        comm_inter : MPI communicator
-                     inter-isle communicator for migration
         migration_prob : float
                          per-worker migration probability
         emigration_propagator : propulate.propagators.Propagator
@@ -95,7 +92,6 @@ class PolliPropulator:
         self.generation = 0
         self.isle_idx = int(isle_idx)  # isle index
         self.comm = comm  # intra-isle communicator
-        self.comm_inter = comm_inter  # inter-isle communicator
         self.checkpoint_path = Path(checkpoint_path)
         self.migration_prob = float(migration_prob)  # per-rank migration probability
         self.migration_topology = migration_topology  # migration topology
@@ -161,9 +157,8 @@ class PolliPropulator:
                       number of currently active individuals
         """
         active_pop = [ind for ind in self.population if ind.active]
-        num_actives = len(active_pop)
 
-        return active_pop, num_actives
+        return active_pop, len(active_pop)
 
     def _breed(self):
         """
@@ -705,8 +700,10 @@ class PolliPropulator:
                    path to results plot (rank-specific loss vs. generation)
         """
         top_n = int(top_n)
-        active_pop, _ = self._get_active_individuals()
-        total = self.comm_inter.reduce(len(active_pop), root=0)
+        active_pop, num_active = self._get_active_individuals()
+        assert (np.all( np.array(self.comm.allgather(num_active), dtype=int) == num_active ))
+        total = int(MPI.COMM_WORLD.allreduce(num_active/self.unique_counts[self.isle_idx]))
+
         MPI.COMM_WORLD.barrier()
         if MPI.COMM_WORLD.rank == 0:
             print("\n###########")
@@ -716,8 +713,9 @@ class PolliPropulator:
                 f"Number of currently active individuals is {total}. "
                 f"\nExpected overall number of evaluations is {self.generations*MPI.COMM_WORLD.size}."
             )
-        populations = self.comm.gather(self.population, root=0)
+        # Only double-check number of occurrences of each individual for DEBUG level 2.
         if DEBUG == 2:
+            populations = self.comm.gather(self.population, root=0)
             occurrences, _ = self._check_for_duplicates(True, DEBUG)
             if self.comm.rank == 0:
                 if self._check_intra_isle_synchronization(populations):
@@ -729,43 +727,18 @@ class PolliPropulator:
                 res_str += f"I{self.isle_idx}: {len(active_pop)}/{len(self.population)} individuals active ({len(occurrences)} unique)."
                 print(res_str)
         MPI.COMM_WORLD.barrier()
-        best = None
         if DEBUG == 0:
+            best = min(self.population, key=attrgetter("loss"))
             if self.comm.rank == 0:
-                best = min(self.population, key=attrgetter("loss"))
-                res_str = f"Top result on isle {self.isle_idx}: {best}\n"
-                print(res_str)
-            best = self.comm.bcast(best, root=0)
+               res_str = f"Top result on isle {self.isle_idx}: {best}\n"
+               print(res_str)
         else:
+            unique_pop = self._get_unique_individuals()
+            unique_pop.sort(key=lambda x: x.loss)
+            best = unique_pop[:top_n]
             if self.comm.rank == 0:
-                unique_pop = self._get_unique_individuals()
-                unique_pop.sort(key=lambda x: x.loss)
-                best = unique_pop[:top_n]
                 res_str = f"Top {top_n} result(s) on isle {self.isle_idx}:\n"
                 for i in range(top_n):
                     res_str += f"({i+1}): {unique_pop[i]}\n"
                 print(res_str)
-            best = self.comm.bcast(best, root=0)
-
-        if self.comm.rank == 0:
-            import matplotlib.pyplot as plt
-
-            xs = [x.generation for x in self.population]
-            ys = [x.loss for x in self.population]
-            zs = [x.rank for x in self.population]
-
-            fig, ax = plt.subplots()
-            scatter = ax.scatter(xs, ys, c=zs)
-            plt.xlabel("Generation")
-            plt.ylabel("Loss")
-            ax.legend(*scatter.legend_elements(), title="Rank")
-            plt.savefig(f"isle_{self.isle_idx}_{out_file}")
-            plt.close()
-            if self.migration_prob > 0.:
-                Best = self.comm_inter.gather(best, root=0)
-
-        MPI.COMM_WORLD.barrier()
-        if MPI.COMM_WORLD.rank != 0:
-            Best = None
-        Best = MPI.COMM_WORLD.bcast(Best, root=0)
-        return Best
+        return MPI.COMM_WORLD.allgather(best)

--- a/propulate/propulator.py
+++ b/propulate/propulator.py
@@ -29,7 +29,6 @@ class Propulator:
         generations=0,
         checkpoint_path=Path('./'),
         migration_topology=None,
-        comm_inter=MPI.COMM_WORLD,
         migration_prob=0.,
         emigration_propagator=None,
         unique_ind=None,
@@ -58,8 +57,6 @@ class Propulator:
         migration_topology : numpy array
                              2D matrix where entry (i,j) specifies how many
                              individuals are sent by isle i to isle j
-        comm_inter : MPI communicator
-                     inter-isle communicator for migration
         migration_prob : float
                          per-worker migration probability
         emigration_propagator : propulate.propagators.Propagator
@@ -88,7 +85,6 @@ class Propulator:
         self.generation = 0 # current generation not yet evaluated
         self.isle_idx = int(isle_idx)  # isle index
         self.comm = comm  # intra-isle communicator
-        self.comm_inter = comm_inter  # inter-isle communicator
 
         self.checkpoint_path = Path(checkpoint_path)
         self.checkpoint_path.mkdir(parents=True, exist_ok=True)
@@ -155,9 +151,8 @@ class Propulator:
                       number of currently active individuals
         """
         active_pop = [ind for ind in self.population if ind.active]
-        num_actives = len(active_pop)
 
-        return active_pop, num_actives
+        return active_pop, len(active_pop)
 
     def _breed(self):
         """
@@ -748,8 +743,10 @@ class Propulator:
                    path to results plot (rank-specific loss vs. generation)
         """
         top_n = int(top_n)
-        active_pop, _ = self._get_active_individuals()
-        total = self.comm_inter.reduce(len(active_pop), root=0)
+        active_pop, num_active = self._get_active_individuals()
+        assert (np.all( np.array(self.comm.allgather(num_active), dtype=int) == num_active ))
+        total = int(MPI.COMM_WORLD.allreduce(num_active/self.unique_counts[self.isle_idx]))
+
         MPI.COMM_WORLD.barrier()
         if MPI.COMM_WORLD.rank == 0:
             print("\n###########")
@@ -759,9 +756,9 @@ class Propulator:
                 f"Number of currently active individuals is {total}. "
                 f"\nExpected overall number of evaluations is {self.generations*MPI.COMM_WORLD.size}."
             )
-        populations = self.comm.gather(self.population, root=0)
         # Only double-check number of occurrences of each individual for DEBUG level 2.
         if DEBUG == 2:
+            populations = self.comm.gather(self.population, root=0)
             occurrences, _ = self._check_for_duplicates(True, DEBUG)
             if self.comm.rank == 0:
                 if self._check_intra_isle_synchronization(populations):
@@ -773,41 +770,18 @@ class Propulator:
                 res_str += f"I{self.isle_idx}: {len(active_pop)}/{len(self.population)} individuals active ({len(occurrences)} unique)."
                 print(res_str)
         MPI.COMM_WORLD.barrier()
-        best = None
         if DEBUG == 0:
+            best = min(self.population, key=attrgetter("loss"))
             if self.comm.rank == 0:
-                best = min(self.population, key=attrgetter("loss"))
-                res_str = f"Top result on isle {self.isle_idx}: {best}\n"
-                print(res_str)
-            best = self.comm.bcast(best, root=0)
+               res_str = f"Top result on isle {self.isle_idx}: {best}\n"
+               print(res_str)
         else:
+            unique_pop = self._get_unique_individuals()
+            unique_pop.sort(key=lambda x: x.loss)
+            best = unique_pop[:top_n]
             if self.comm.rank == 0:
-                unique_pop = self._get_unique_individuals()
-                unique_pop.sort(key=lambda x: x.loss)
-                best = unique_pop[:top_n]
                 res_str = f"Top {top_n} result(s) on isle {self.isle_idx}:\n"
                 for i in range(top_n):
                     res_str += f"({i+1}): {unique_pop[i]}\n"
                 print(res_str)
-            best = self.comm.bcast(best, root=0)
-
-        if self.comm.rank == 0:
-            import matplotlib.pyplot as plt
-
-            xs = [x.generation for x in self.population]
-            ys = [x.loss for x in self.population]
-            zs = [x.rank for x in self.population]
-
-            fig, ax = plt.subplots()
-            scatter = ax.scatter(xs, ys, c=zs)
-            plt.xlabel("Generation")
-            plt.ylabel("Loss")
-            ax.legend(*scatter.legend_elements(), title="Rank")
-            plt.savefig(f"isle_{self.isle_idx}_{out_file}")
-            plt.close()
-            Best = self.comm_inter.gather(best, root=0)
-        MPI.COMM_WORLD.barrier()
-        if MPI.COMM_WORLD.rank != 0:
-            Best = None
-        Best = MPI.COMM_WORLD.bcast(Best, root=0)
-        return Best
+        return MPI.COMM_WORLD.allgather(best)


### PR DESCRIPTION
Adresses #39. I removed the inter-island communicator completely as it was more or less unused or rather only used for things that could also be accomplished more easily (without creating an additional communicator). The only real occurrence was calculating the overall number of individuals evaluated on all islands together. This is now done differently.