### PR TITLE
added if clause for more than two given ordinal parameters

### DIFF
--- a/propulate/propagators/base.py
+++ b/propulate/propagators/base.py
@@ -537,7 +537,10 @@ class InitUniform(Stochastic):
                 if isinstance(
                     self.limits[limit][0], int
                 ):  # If ordinal trait of type integer.
-                    position[limit] = self.rng.randint(*self.limits[limit])
+                    if len(self.limits[limit]) == 2:  # Selecting one value in range of ordinal parameter
+                        position[limit] = self.rng.randint(*self.limits[limit])
+                    else:  # Selecting one distinct value from ordinal parameters
+                        position[limit] = self.rng.choice(self.limits[limit])
                 elif isinstance(
                     self.limits[limit][0], float
                 ):  # If interval trait of type float.


### PR DESCRIPTION
If a tuple for ordinal parameters contains more than two values, an error was raised by random.randint.
If more than two parameters are now specified, a distinct value is selected from the tuple. 