### PR TITLE
Fix MacOS MPICH tests for Python 3.11 and 3.12

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -12,16 +12,9 @@ jobs:
     build:
         strategy:
           matrix:
-            os: ["ubuntu-latest", "macos-latest"] # "windows-latest"
+            os: ["ubuntu-latest", "macos-latest"]
             python-version: ["3.10", "3.11", "3.12" ]
-            mpi: [ "openmpi", "mpich"] #, "intelmpi", "windowsmpi"]
-#            exclude:
-#              - os: "macos-latest"
-#                mpi: ["intelmpi", "windowsmpi"]
-#              - os: "windows-latest"
-#                mpi: ["openmpi", "mpich"]
-#              - os: "ubuntu-latest"
-#                mpi: ["windowsmpi"]
+            mpi: [ "openmpi", "mpich"]
 
         runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
# Description

A new problem appeared after merging the new test workflow into main, causing some tests to fail. This was apparently due to caching issues caused by uv, which led to misconfigured MPI (mpi4py looking for OpenMPI when MPICH was built and vice versa). I disabled cache for uv which seems to fix the error, at least in the current branch. I have no idea why this problem did not occur in the dev branch before.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes